### PR TITLE
chore: プロジェクト名を fast-knapsack-cython から fast-knapsack-benchmark に変更 (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fast-knapsack-cython
+# fast-knapsack-benchmark
 ## 実務制約付きナップサック問題に対する時間予算ベースの解法比較
 
 3行サマリ:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "fast-knapsack-cython"
+name = "fast-knapsack-benchmark"
 version = "0.1.0"
 description = "Time-budget benchmark of Cython, Numba, and MiniZinc solvers for a constrained large-scale knapsack problem."
 readme = "README.md"

--- a/src/solver_cython/setup.py
+++ b/src/solver_cython/setup.py
@@ -14,7 +14,7 @@ ext_modules = [
 ]
 
 setup(
-    name="fast-knapsack-cython-core",
+    name="fast-knapsack-benchmark-core",
     ext_modules=cythonize(ext_modules, compiler_directives={"language_level": "3"}),
     packages=["solver_cython"],
     package_dir={"": "src"},

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 ]
 
 [[package]]
-name = "fast-knapsack-cython"
+name = "fast-knapsack-benchmark"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
Closes #22

## 変更内容
- pyproject.toml: name を ast-knapsack-benchmark に更新
- README.md: 冒頭タイトルを ast-knapsack-benchmark に更新
- src/solver_cython/setup.py: name を ast-knapsack-benchmark-core に更新